### PR TITLE
Gradle support

### DIFF
--- a/MapEver/build.gradle
+++ b/MapEver/build.gradle
@@ -1,0 +1,35 @@
+apply plugin: 'com.android.application'
+
+dependencies {
+    compile project(':OpenCV-2.4.9-android-sdk:sdk:java')
+    compile 'com.android.support:appcompat-v7:21.0.3'
+}
+
+android {
+    compileSdkVersion 21
+    buildToolsVersion "22.0.1"
+
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+            java.srcDirs = ['src']
+            resources.srcDirs = ['src']
+            aidl.srcDirs = ['src']
+            renderscript.srcDirs = ['src']
+            res.srcDirs = ['res']
+            assets.srcDirs = ['assets']
+        }
+
+        // Move the tests to tests/java, tests/res, etc...
+        instrumentTest.setRoot('tests')
+
+        // Move the build types to build-types/<type>
+        // For instance, build-types/debug/java, build-types/debug/AndroidManifest.xml, ...
+        // This moves them out of them default location under src/<type>/... which would
+        // conflict with src/ being used by the main source set.
+        // Adding new build types or product flavors should be accompanied
+        // by a similar customization.
+        debug.setRoot('build-types/debug')
+        release.setRoot('build-types/release')
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,9 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:1.2.3'
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+include ':OpenCV-2.4.9-android-sdk:sdk:java'
+include ':MapEver'


### PR DESCRIPTION
Adds gradle files and some other stuff AndroidStudio wants.
Should make it easier for people to get started with the project, in particular getting rid of magic steps like "copy the appcompat directory from the SDK to the checkout directory" etc.
Still not happy about the buildsystem crapping its files all over the place though.
