### PR TITLE
Revert c50c28e64c6c8726b55159763e1d6785fab464c5

### DIFF
--- a/MapEver/src/de/hu_berlin/informatik/spws2014/mapever/Start.java
+++ b/MapEver/src/de/hu_berlin/informatik/spws2014/mapever/Start.java
@@ -123,7 +123,7 @@ public class Start extends BaseActivity {
 		Resources resources = getResources();
 		
 		// get a list of all maps from the databse
-		if (!TrackDB.loadDB(new File(getApplicationContext().getApplicationInfo().dataDir))) {
+		if (!TrackDB.loadDB(new File(MapEverApp.getAbsoluteFilePath("")))) {
 			Log.e("Start", "Could not start DB!");
 			System.exit(-1);
 		}

--- a/MapEver/src/de/hu_berlin/informatik/spws2014/mapever/navigation/Navigation.java
+++ b/MapEver/src/de/hu_berlin/informatik/spws2014/mapever/navigation/Navigation.java
@@ -474,7 +474,7 @@ public class Navigation extends BaseActivity implements LocationListener {
 			// => Lade nichts aus der Datenbank, sondern benutze nichtpersistenten LDM. (Debugging)
 			iLDMIOHandler = new LDMIOEmpty();
 		} else {
-			if (!TrackDB.loadDB(new File(getApplicationContext().getApplicationInfo().dataDir))) {
+			if (!TrackDB.loadDB(new File(MapEverApp.getAbsoluteFilePath("")))) {
 				Log.e("Nav", "Could not load DB");
 				finish();
 			}


### PR DESCRIPTION
Switching to datadir, and only for .track files was a stupid idea
by me...
The "directory not found" issue I had seems to have been a temporary
glitch.
But even if it wasn't, the getAbsoluteFilePath implementation could
be changed to use it.
For e.g. backup and also due to the potentially small size of the
app partition, using the sdcard location that getAbsoluteFilePath
uses is probably indeed the better choice.
The standard "data dir" might be better for privacy reason though
(and would allow different app variants to have different data),
so making it an option at some point might make sense.
That should still be done via changing getAbsoluteFilePath so that
all data files end up in the same place.

Signed-off-by: Reimar Döffinger Reimar.Doeffinger@gmx.de
