### PR TITLE
Allow zooming map with keyboard dot and comma.

### DIFF
--- a/MapEver/src/de/hu_berlin/informatik/spws2014/mapever/largeimageview/LargeImageView.java
+++ b/MapEver/src/de/hu_berlin/informatik/spws2014/mapever/largeimageview/LargeImageView.java
@@ -28,6 +28,7 @@ import android.os.Bundle;
 import android.os.Parcelable;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
 import android.widget.ImageView;
@@ -631,6 +632,18 @@ public class LargeImageView extends ImageView {
 	// //////////// TOUCH AND CLICK EVENT HANDLING
 	// ////////////////////////////////////////////////////////////////////////
 	
+	// To allow zooming with keyboard (e.g. emulator)
+	@Override
+	public boolean onKeyDown(int code, KeyEvent event) {
+		if (code == KeyEvent.KEYCODE_COMMA) {
+			setZoomScale(zoomScale * 2);
+			return true;
+		} else if (code == KeyEvent.KEYCODE_PERIOD) {
+			setZoomScale(zoomScale / 2);
+			return true;
+		}
+		return super.onKeyDown(code, event);
+	}
 	// ////// MAIN ONTOUCHEVENT
 	
 	/**

--- a/MapEver/src/de/hu_berlin/informatik/spws2014/mapever/navigation/Navigation.java
+++ b/MapEver/src/de/hu_berlin/informatik/spws2014/mapever/navigation/Navigation.java
@@ -184,6 +184,8 @@ public class Navigation extends BaseActivity implements LocationListener {
 		
 		// Initialisieren der ben�tigten Komponenten
 		mapView = (MapView) findViewById(R.id.map);
+		mapView.setFocusable(true);
+		mapView.setFocusableInTouchMode(true);
 		
 		// Initialisieren der Buttons & Eintragen in die Liste
 		setRefPointButton = (ImageButton) findViewById(R.id.set_refpoint);


### PR DESCRIPTION
Dot and comma chosen because they were easiest to
get working.
It is mostly a feature for testing for me.
Though admittedly adding zoom-in/zoom-out buttons
might have been a better solution.

Signed-off-by: Reimar Döffinger Reimar.Doeffinger@gmx.de
