### PR TITLE
Deskewing actually works without OpenCV.

### DIFF
--- a/MapEver/res/values-de/strings.xml
+++ b/MapEver/res/values-de/strings.xml
@@ -59,7 +59,7 @@
     <string name="deskewing_error_invalidcorners">Anordnung der Eckpunkte so nicht möglich!</string>
     <string name="deskewing_error_deskewfailure">Entzerrung fehlgeschlagen!</string>
     <string name="deskewing_imagetype_not_supported">Die Entzerrung wird für dieses Bildformat nicht unterstützt!</string>
-    <string name="deskewing_opencv_not_available">OpenCV für Entzerrung ist nicht verfügbar!</string>
+    <string name="deskewing_opencv_not_available">OpenCV für Eckpunkterkennung ist nicht verfügbar!</string>
 
     <!-- ContentDescriptions of images -->
     <string name="deskewing_desc_do_deskew">Button, der die Entzerrung ausführt</string>

--- a/MapEver/res/values/strings.xml
+++ b/MapEver/res/values/strings.xml
@@ -60,7 +60,7 @@
     <string name="deskewing_error_invalidcorners">Invalid arrangement of corners!</string>
     <string name="deskewing_error_deskewfailure">Deskewing failed!</string>
     <string name="deskewing_imagetype_not_supported">Image type is not supported to be deskewed!</string>
-    <string name="deskewing_opencv_not_available">OpenCV not available for deskewing!</string>
+    <string name="deskewing_opencv_not_available">OpenCV not available for corner detection!</string>
 
     <!-- ContentDescriptions of images -->
     <string name="deskewing_desc_do_deskew">Button for deskewing the image</string>

--- a/MapEver/src/de/hu_berlin/informatik/spws2014/mapever/entzerrung/EntzerrungsView.java
+++ b/MapEver/src/de/hu_berlin/informatik/spws2014/mapever/entzerrung/EntzerrungsView.java
@@ -451,8 +451,6 @@ public class EntzerrungsView extends LargeImageView {
 		}
 		catch (UnsatisfiedLinkError e) {
 			Log.w("EntzerrungsView/calcCornersWithDetector", "OpenCV not available");
-			showCorners(false);
-			imageTypeSupportsDeskew = false;
 			openCVLoadError = true;
 			calcCornerDefaults();
 			return;


### PR DESCRIPTION
Re-enable it even when OpenCV cannot be loaded.
