### PR TITLE
Fix data loss in connection with geo: intents.

### DIFF
--- a/MapEver/src/de/hu_berlin/informatik/spws2014/mapever/Start.java
+++ b/MapEver/src/de/hu_berlin/informatik/spws2014/mapever/Start.java
@@ -114,6 +114,17 @@ public class Start extends BaseActivity {
 		Log.d("Start", "onCreate..." + (savedInstanceState != null ? " with savedInstanceState" : ""));
 		super.onCreate(savedInstanceState);
 		
+		// We do not want to have multiple instances, as that ends up with race
+		// conditions on reading/writing the data files.
+		// Using singleTask for this is simply broken.
+		// So instead forward the intent to a "clean" task if necessary
+		if (!isTaskRoot() && (getIntent().getFlags() & (Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK)) == 0) {
+			getIntent().setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
+			startActivity(getIntent());
+			finish();
+			return;
+		}
+
 		if (savedInstanceState == null) {
 			Intent intent = getIntent();
 			if (intent != null && intent.getBooleanExtra(INTENT_EXIT, false)) {


### PR DESCRIPTION
When geo: intents are handled by activities created
in a different task, that can lead to the same map
being opened multiple times (once in each task).
The way the maps are implemented, this means that the
last to call onPause/onDestroy will "win" its reference
points will end up on disk.
This is particularly annoying if that one is the one
that has no reference points and you lost all
that you added...
Solve it via a horrible hack that always uses a new, clean
task (of which there should be only one).

Signed-off-by: Reimar Döffinger Reimar.Doeffinger@gmx.de
